### PR TITLE
Fix release lint workflow

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -13,7 +13,7 @@ plugins:
 runtimes:
   enabled:
     - go@1.21.0
-    - node@18.12.1
+    - node@22.16.0
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:

--- a/.version.sh
+++ b/.version.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -z "$(git tag --points-at HEAD)" ]; then
+tags="$(git tag --points-at HEAD)"
+
+if [[ -z ${tags} ]]; then
 	git describe --always --long --dirty | sed 's/^v//'
 else
-	git tag --points-at HEAD | sed 's/^v//' | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | tail -n 1
+	printf '%s\n' "${tags}" | sed 's/^v//' | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | tail -n 1
 fi


### PR DESCRIPTION
Fix the tag-triggered release workflow by upgrading Trunk's Node runtime for markdownlint and making .version.sh shellcheck-compliant.

Validated with the full tracked-file Trunk scan, pytest, Pyright, and Ruff.